### PR TITLE
在输入法修复的说明中添加安装 archlinuxcn-keyring 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,6 @@ Server = http://repo.archlinuxcn.org/$arch
 ```
 ```
 sudo pacman -Syy
+sudo pacman -S archlinuxcn-keyring
 sudo pacman -S telegram-desktop-cn
 ```


### PR DESCRIPTION
否则没用签名验证应该是没法直接装的
